### PR TITLE
fixed weapons, shield and armor of total ships

### DIFF
--- a/implementations/2Moons/1_7_2_injectionMode/calculateAttack.php
+++ b/implementations/2Moons/1_7_2_injectionMode/calculateAttack.php
@@ -289,9 +289,9 @@ function getShipType($id, $count)
     $CombatCaps = $GLOBALS['CombatCaps'];
     $pricelist = $GLOBALS['pricelist'];
     $rf = isset($CombatCaps[$id]['sd']) ? $CombatCaps[$id]['sd'] : 0;
-    $shield = $CombatCaps[$id]['shield'];
-    $cost = array($pricelist[$id]['cost'][METAL_ID], $pricelist[$id]['cost'][CRYSTAL_ID]);
-    $power = $CombatCaps[$id]['attack'];
+    $shield = $CombatCaps[$id]['shield'] * $count;
+    $cost = array($count * ($pricelist[$id]['cost'][METAL_ID] + $pricelist[$id]['cost'][CRYSTAL_ID]));
+    $power = $CombatCaps[$id]['attack'] * $count;
     if ($id > ID_MIN_SHIPS && $id < ID_MAX_SHIPS)
     {
         return new Ship($id, $count, $rf, $shield, $cost, $power);


### PR DESCRIPTION
Solo muestra la cantidad de armas, escudo y blindaje de una sola nave sin importar la cantidad que envíes Ejemplo:
Tipo de naves: Estrella de la Muerte
Cantidad: 20
Armas: 200.000
Escudo: 50.000
Blindaje: 900.000